### PR TITLE
GEN-1679:  Get chat completion by its ID

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "macrocosmos",
-  "version": "1.2.24",
+  "version": "1.2.25",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "macrocosmos",
-      "version": "1.2.24",
+      "version": "1.2.25",
       "license": "Apache-2.0",
       "dependencies": {
         "@grpc/grpc-js": "^1.10.1",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "macrocosmos",
-  "version": "1.2.25",
+  "version": "1.2.26",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "macrocosmos",
-      "version": "1.2.25",
+      "version": "1.2.26",
       "license": "Apache-2.0",
       "dependencies": {
         "@grpc/grpc-js": "^1.10.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "macrocosmos",
-  "version": "1.2.25",
+  "version": "1.2.26",
   "description": "TypeScript SDK package for Macrocosmos",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "macrocosmos",
-  "version": "1.2.24",
+  "version": "1.2.25",
   "description": "TypeScript SDK package for Macrocosmos",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/protos/apex/v1/apex.proto
+++ b/protos/apex/v1/apex.proto
@@ -25,7 +25,7 @@ service ApexService {
   rpc GetDeepResearcherJob(GetDeepResearcherJobRequest) returns (GetDeepResearcherJobResponse);
 
   // GetChatSessions retrieves a user's chats
-  rpc GetChatSessions(google.protobuf.Empty) returns (GetChatSessionsResponse);
+  rpc GetChatSessions(GetChatSessionsRequest) returns (GetChatSessionsResponse);
 
   // GetStoredChatCompletions retrieves a chat's completions
   rpc GetStoredChatCompletions(GetStoredChatCompletionsRequest) returns (GetStoredChatCompletionsResponse);
@@ -461,6 +461,12 @@ message GetChatSessionsResponse {
   repeated ChatSession chat_sessions = 1;
 }
 
+// A GetChatSessionsRequest message
+message GetChatSessionsRequest {
+  // chat_type: type of chat (e.g. "apex" or "gravity")
+  string chat_type = 1;
+}
+
 // A GetStoredChatCompletionRequest request message
 message GetStoredChatCompletionsRequest {
   // chat_id: a unique identifier for a chat
@@ -495,6 +501,7 @@ message GetStoredChatCompletionsResponse {
   // chat_completions: the chat completions
   repeated StoredChatCompletion chat_completions = 1;
 }
+
 // Directly model the attributes as a map
 message UpdateChatAttributesRequest {
   // chat_id: the unique id associated to a users chat message

--- a/src/__tests__/apex/client-chat.test.ts
+++ b/src/__tests__/apex/client-chat.test.ts
@@ -179,6 +179,47 @@ describe("ApexClient", () => {
     ).toBe(false);
   }, 30000);
 
+  it("should retrieve a completion", async () => {
+    // chat ID for testing
+    const create_chat_result = await client.createChatAndCompletion(
+      createChatAndCompletionParams,
+    );
+
+    // Verify create chat was successful
+    console.log("Create chat response:", create_chat_result);
+    expect(create_chat_result).toBeDefined();
+
+    // Delete test chat
+    const get_chat_completion_result = await client.getChatCompletion({
+      completionId: create_chat_result.parsedCompletion?.id ?? "",
+    });
+
+    // Make sure the retrieved completion matches the created one
+    expect(get_chat_completion_result).toBeDefined();
+    expect(get_chat_completion_result.id).toBe(
+      create_chat_result.parsedCompletion?.id,
+    );
+    expect(get_chat_completion_result.chatId).toBe(
+      create_chat_result.parsedChat?.id,
+    );
+    expect(get_chat_completion_result.completionType).toBe(
+      create_chat_result.parsedCompletion?.completionType,
+    );
+    expect(get_chat_completion_result.createdAt?.toISOString()).toBe(
+      create_chat_result.parsedCompletion?.createdAt?.toISOString(),
+    );
+    expect(get_chat_completion_result.userPromptText).toBe(
+      create_chat_result.parsedCompletion?.userPromptText,
+    );
+    expect(get_chat_completion_result.metadata).toStrictEqual(
+      create_chat_result.parsedCompletion?.metadata,
+    );
+    const delete_chat_result = await client.deleteChats({
+      chatIds: [create_chat_result.parsedChat?.id ?? ""],
+    });
+    expect(delete_chat_result.success).toBeTruthy();
+  }, 30000);
+
   it("should delete a completion", async () => {
     // chat ID for testing
     const create_completion_result = await client.createChatAndCompletion(

--- a/src/__tests__/apex/client-chat.test.ts
+++ b/src/__tests__/apex/client-chat.test.ts
@@ -163,7 +163,9 @@ describe("ApexClient", () => {
     });
     expect(delete_chat_result).toBeDefined();
     expect(delete_chat_result.success).toBeTruthy();
-    const get_chat_sessions_result = await client.getChatSessions();
+    const get_chat_sessions_result = await client.getChatSessions({
+      chatType: "apex",
+    });
 
     // Verify the response structure
     console.log("Stored chats:", get_chat_sessions_result);
@@ -310,7 +312,9 @@ describe("ApexClient", () => {
 
   it("should retrieve a user's stored chats", async () => {
     // Get stored chat completions
-    const result = await client.getChatSessions();
+    const result = await client.getChatSessions({
+      chatType: "apex",
+    });
 
     // Verify the response structure
     console.log("Stored chats:", result);

--- a/src/generated/apex/v1/apex.ts
+++ b/src/generated/apex/v1/apex.ts
@@ -484,6 +484,12 @@ export interface GetChatSessionsResponse {
   chatSessions: ChatSession[];
 }
 
+/** A GetChatSessionsRequest message */
+export interface GetChatSessionsRequest {
+  /** chat_type: type of chat (e.g. "apex" or "gravity") */
+  chatType: string;
+}
+
 /** A GetStoredChatCompletionRequest request message */
 export interface GetStoredChatCompletionsRequest {
   /** chat_id: a unique identifier for a chat */
@@ -4756,6 +4762,77 @@ export const GetChatSessionsResponse: MessageFns<GetChatSessionsResponse> = {
   },
 };
 
+function createBaseGetChatSessionsRequest(): GetChatSessionsRequest {
+  return { chatType: "" };
+}
+
+export const GetChatSessionsRequest: MessageFns<GetChatSessionsRequest> = {
+  encode(
+    message: GetChatSessionsRequest,
+    writer: BinaryWriter = new BinaryWriter(),
+  ): BinaryWriter {
+    if (message.chatType !== "") {
+      writer.uint32(10).string(message.chatType);
+    }
+    return writer;
+  },
+
+  decode(
+    input: BinaryReader | Uint8Array,
+    length?: number,
+  ): GetChatSessionsRequest {
+    const reader =
+      input instanceof BinaryReader ? input : new BinaryReader(input);
+    let end = length === undefined ? reader.len : reader.pos + length;
+    const message = createBaseGetChatSessionsRequest();
+    while (reader.pos < end) {
+      const tag = reader.uint32();
+      switch (tag >>> 3) {
+        case 1: {
+          if (tag !== 10) {
+            break;
+          }
+
+          message.chatType = reader.string();
+          continue;
+        }
+      }
+      if ((tag & 7) === 4 || tag === 0) {
+        break;
+      }
+      reader.skip(tag & 7);
+    }
+    return message;
+  },
+
+  fromJSON(object: any): GetChatSessionsRequest {
+    return {
+      chatType: isSet(object.chatType)
+        ? globalThis.String(object.chatType)
+        : "",
+    };
+  },
+
+  toJSON(message: GetChatSessionsRequest): unknown {
+    const obj: any = {};
+    if (message.chatType !== "") {
+      obj.chatType = message.chatType;
+    }
+    return obj;
+  },
+
+  create(base?: DeepPartial<GetChatSessionsRequest>): GetChatSessionsRequest {
+    return GetChatSessionsRequest.fromPartial(base ?? {});
+  },
+  fromPartial(
+    object: DeepPartial<GetChatSessionsRequest>,
+  ): GetChatSessionsRequest {
+    const message = createBaseGetChatSessionsRequest();
+    message.chatType = object.chatType ?? "";
+    return message;
+  },
+};
+
 function createBaseGetStoredChatCompletionsRequest(): GetStoredChatCompletionsRequest {
   return { chatId: "" };
 }
@@ -6944,9 +7021,9 @@ export const ApexServiceService = {
     path: "/apex.v1.ApexService/GetChatSessions",
     requestStream: false,
     responseStream: false,
-    requestSerialize: (value: Empty) =>
-      Buffer.from(Empty.encode(value).finish()),
-    requestDeserialize: (value: Buffer) => Empty.decode(value),
+    requestSerialize: (value: GetChatSessionsRequest) =>
+      Buffer.from(GetChatSessionsRequest.encode(value).finish()),
+    requestDeserialize: (value: Buffer) => GetChatSessionsRequest.decode(value),
     responseSerialize: (value: GetChatSessionsResponse) =>
       Buffer.from(GetChatSessionsResponse.encode(value).finish()),
     responseDeserialize: (value: Buffer) =>
@@ -7109,7 +7186,10 @@ export interface ApexServiceServer extends UntypedServiceImplementation {
     GetDeepResearcherJobResponse
   >;
   /** GetChatSessions retrieves a user's chats */
-  getChatSessions: handleUnaryCall<Empty, GetChatSessionsResponse>;
+  getChatSessions: handleUnaryCall<
+    GetChatSessionsRequest,
+    GetChatSessionsResponse
+  >;
   /** GetStoredChatCompletions retrieves a chat's completions */
   getStoredChatCompletions: handleUnaryCall<
     GetStoredChatCompletionsRequest,
@@ -7267,14 +7347,14 @@ export interface ApexServiceClient extends Client {
   ): ClientUnaryCall;
   /** GetChatSessions retrieves a user's chats */
   getChatSessions(
-    request: Empty,
+    request: GetChatSessionsRequest,
     callback: (
       error: ServiceError | null,
       response: GetChatSessionsResponse,
     ) => void,
   ): ClientUnaryCall;
   getChatSessions(
-    request: Empty,
+    request: GetChatSessionsRequest,
     metadata: Metadata,
     callback: (
       error: ServiceError | null,
@@ -7282,7 +7362,7 @@ export interface ApexServiceClient extends Client {
     ) => void,
   ): ClientUnaryCall;
   getChatSessions(
-    request: Empty,
+    request: GetChatSessionsRequest,
     metadata: Metadata,
     options: Partial<CallOptions>,
     callback: (

--- a/src/lib/apex/Client.ts
+++ b/src/lib/apex/Client.ts
@@ -26,6 +26,7 @@ import {
   UpdateChatAttributesResponse,
   UpdateCompletionAttributesRequest,
   UpdateCompletionAttributesResponse,
+  GetChatSessionsRequest,
 } from "../../generated/apex/v1/apex";
 import * as grpc from "@grpc/grpc-js";
 import { BaseClient, BaseClientOptions } from "../BaseClient";
@@ -283,12 +284,14 @@ export class ApexClient extends BaseClient {
   /**
    * Get the user's stored chats
    */
-  getChatSessions = async (): Promise<GetChatSessionsResponse> => {
+  getChatSessions = async (
+    params: GetChatSessionsRequest,
+  ): Promise<GetChatSessionsResponse> => {
     const client = this.createGrpcClient();
 
     return new Promise<GetChatSessionsResponse>((resolve, reject) => {
       client.getChatSessions(
-        {},
+        params,
         (
           error: grpc.ServiceError | null,
           response: GetChatSessionsResponse,

--- a/src/lib/apex/Client.ts
+++ b/src/lib/apex/Client.ts
@@ -477,4 +477,30 @@ export class ApexClient extends BaseClient {
       },
     );
   };
+  /**
+   * GetCompletion by ID endpoint
+   */
+  updateCompletionAttributes = async (
+    params: UpdateCompletionAttributesRequest,
+  ): Promise<UpdateCompletionAttributesResponse> => {
+    const client = this.createGrpcClient();
+
+    return new Promise<UpdateCompletionAttributesResponse>(
+      (resolve, reject) => {
+        client.updateCompletionAttributes(
+          params,
+          (
+            error: grpc.ServiceError | null,
+            response: UpdateCompletionAttributesResponse,
+          ) => {
+            if (error) {
+              reject(error);
+              return;
+            }
+            resolve(response);
+          },
+        );
+      },
+    );
+  };
 }

--- a/src/lib/apex/Client.ts
+++ b/src/lib/apex/Client.ts
@@ -27,6 +27,8 @@ import {
   UpdateCompletionAttributesRequest,
   UpdateCompletionAttributesResponse,
   GetChatSessionsRequest,
+  GetChatCompletionRequest,
+  StoredChatCompletion,
 } from "../../generated/apex/v1/apex";
 import * as grpc from "@grpc/grpc-js";
 import { BaseClient, BaseClientOptions } from "../BaseClient";
@@ -478,29 +480,24 @@ export class ApexClient extends BaseClient {
     );
   };
   /**
-   * GetCompletion by ID endpoint
+   * GetCompletion by ID client
    */
-  updateCompletionAttributes = async (
-    params: UpdateCompletionAttributesRequest,
-  ): Promise<UpdateCompletionAttributesResponse> => {
+  getChatCompletion = async (
+    params: GetChatCompletionRequest,
+  ): Promise<StoredChatCompletion> => {
     const client = this.createGrpcClient();
 
-    return new Promise<UpdateCompletionAttributesResponse>(
-      (resolve, reject) => {
-        client.updateCompletionAttributes(
-          params,
-          (
-            error: grpc.ServiceError | null,
-            response: UpdateCompletionAttributesResponse,
-          ) => {
-            if (error) {
-              reject(error);
-              return;
-            }
-            resolve(response);
-          },
-        );
-      },
-    );
+    return new Promise<StoredChatCompletion>((resolve, reject) => {
+      client.getChatCompletion(
+        params,
+        (error: grpc.ServiceError | null, response: StoredChatCompletion) => {
+          if (error) {
+            reject(error);
+            return;
+          }
+          resolve(response);
+        },
+      );
+    });
   };
 }

--- a/src/version.ts
+++ b/src/version.ts
@@ -1,1 +1,1 @@
-export const VERSION = "1.2.25";
+export const VERSION = "1.2.26";

--- a/src/version.ts
+++ b/src/version.ts
@@ -1,1 +1,1 @@
-export const VERSION = "1.2.24";
+export const VERSION = "1.2.25";


### PR DESCRIPTION
This PR:

1. Adds a TS client for the `getChatCompletion` endpoint
2. Adds a test for the `getChatCompletion` endpoint
3. Bumps version to 1.2.26